### PR TITLE
Ideas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 
 # generate output
 dist/
+
+# Sandbox mock state
+state/

--- a/MockApp/Dockerfile
+++ b/MockApp/Dockerfile
@@ -1,4 +1,6 @@
 FROM getsandbox/worker-cli
 ENV WATCH=false
-RUN mkdir -p ~/state
+RUN mkdir -p ~/state \
+    && apt-get update -yqq \
+    && apt-get install curl -yqq
 CMD ["/bin/sh", "-c", "/sandbox-worker-cli ${MEMORY_OPTS:--Xmx128m -Xmx128m -Xss128k} ${JAVA_OPTS:--Dmicronaut.server.netty.worker.threads=2} --base=/base --port=${PORT:-80} --watch=${WATCH} --metadataPort=90 --state=/state/${STATEFILE} ${JAVA_PARAMS} run"]" 

--- a/MockApp/src/main.mjs
+++ b/MockApp/src/main.mjs
@@ -22,3 +22,7 @@ Sandbox.define('/users', 'GET', getUsersHandler);
 
 // Using named route parameters to simulate getting a specific user
 Sandbox.define('/users/{userid}', 'GET', getUserByIdHandler);
+
+Sandbox.define('/health', 'GET', function(req, res) {
+    res.send('OK');
+});

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,10 +32,11 @@ services:
     image: loadimpact/k6
     volumes:
       - ./dist:/dist
+    command: run /dist/tests.js --config /dist/options/smoke.json --http-debug
     environment:
       - APP_DOMAIN=http://mockapp:8080      
     networks: 
-      - mockservice           
+      - mockservice        
 
 networks:
     mockservice:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,10 @@ services:
     environment:
       - "WATCH=true"
       - "STATEFILE=default.json"
+    healthcheck:
+      test: ["CMD", "curl", "http://localhost:8080/health"]
+      interval: 1s
+      retries: 100
     networks: 
       - mockservice            
 
@@ -26,9 +30,9 @@ services:
   k6:
     depends_on:
       build:
-        condition: service_started
+        condition: service_completed_successfully
       mockapp:
-        condition: service_started      
+        condition: service_healthy      
     image: loadimpact/k6
     volumes:
       - ./dist:/dist

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "bundle": "webpack",
     "copyoptions": "mkdir -p ./dist/options/; cp ./src/options/*.json ./dist/options/",
-    "build": "npm install && npm run bundle && npm run copyoptions"
+    "build": "npm ci && npm run bundle && npm run copyoptions"
   },
   "dependencies": {
     "@babel/core": "^7.10.2",

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ APP_DOMAIN=http://localhost:8080 k6 run dist/tests.js --config dist/options/smok
 ## Run in docker
 
 ```bash
-docker-compose run k6 run /dist/tests.js --config /dist/options/smoke.json --http-debug
+docker-compose run --rm k6
 ```
 
 ## Example output


### PR DESCRIPTION
Hey Chris, sorry I missed your leaving.

I've rebased this on your latest. I remember saying I'd had a play with this when learning k6 at work.

* Uses `service_healthy` instead of `service_started` so that you know the app is healthy.
  * Adds nonsense endpoint so you know Java has booted and the API is available
  * Installs curl (required for the healthcheck sadly. 
    * `COPY {someGoLangBinaryThatHealthChecksArbitraryUrls}` might be a better approach
* Switches `build` from `service_started` to `service_completed_successfully`
* pushes command into the docker-compose. While not ideal this gets around cross-os issues running this. For example Docker for windows will try to mount `C:/Program Files/Git/dist/...` 🤷 
* npm ci to avoid overwriting lock file from running.

I Hope you have the best time at your new job.